### PR TITLE
AWS SDK for Ruby のバージョン変更に対応

### DIFF
--- a/ec2manage.gemspec
+++ b/ec2manage.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_runtime_dependency "aws-sdk"
+  spec.add_runtime_dependency "aws-sdk", "~>1"
   spec.add_runtime_dependency "thor"
 end

--- a/lib/ec2manage.rb
+++ b/lib/ec2manage.rb
@@ -1,6 +1,6 @@
 require "ec2manage/version"
 require "ec2manage/instance"
-require "aws-sdk"
+require "aws-sdk-v1"
 
 module Ec2manage
   module Logging


### PR DESCRIPTION
v2への対応が難しかったので、v1を使用するように変更しました。
